### PR TITLE
Escape backslashes in usernames

### DIFF
--- a/connect_to_global_protect_using_nmcli.py
+++ b/connect_to_global_protect_using_nmcli.py
@@ -193,7 +193,7 @@ def connect_to_vpn_using_nmcli(
                     if not node.text:
                         continue
                     if "saml-username" in node.tag.lower():
-                        username = node.text
+                        username = node.text.replace('\\', '\\\\')  # Backslashes need to be escaped if they're part of the username.
                     elif "cookie" in node.tag.lower():
                         cookie = node.text
                     if len(username) and len(cookie):


### PR DESCRIPTION
It turns out that the username string can contain [backslashes](https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-cli-quick-start/cli-cheat-sheets/cli-cheat-sheet-user-id) to delimit between the domain and the username. Using `subprocess` to execute `openconnect` will cause the username to look weird unless the backslashes are properly escaped.

Perhaps these should be passed in via a file or something `stdin`, so that there is no escaping issue.